### PR TITLE
Flatten request body to prevent hackney adding unnecessary headers

### DIFF
--- a/src/gleam_hackney_ffi.erl
+++ b/src/gleam_hackney_ffi.erl
@@ -4,7 +4,7 @@
 
 send(Method, Url, Headers, Body) ->
     Options = [{with_body, true}],
-    case hackney:request(Method, Url, Headers, Body, Options) of
+    case hackney:request(Method, Url, Headers, iolist_to_binary(Body), Options) of
         {ok, Status, ResponseHeaders, ResponseBody} -> 
             {ok, {response, Status, ResponseHeaders, ResponseBody}};
 


### PR DESCRIPTION
Fixes #5. 

Hackney sees a body of `<<>>` as empty and doesn't set any extra headers for it. But it sees `[<<>>]` as a non-empty body of zero length, which [gets](https://github.com/benoitc/hackney/blob/master/src/hackney_request.erl#L351-L398) a content type of `application/octet-stream` and length of `0`. This PR flattens the list of binaries so that hackney can detect the empty body correctly.

Marking as draft for now because I still need to do some testing with non-empty bodies.