### PR TITLE
Replace deprecated result.then() with result.try()

### DIFF
--- a/src/gleam/hackney.gleam
+++ b/src/gleam/hackney.gleam
@@ -27,7 +27,7 @@ fn ffi_send(
 pub fn send_bits(
   request: Request(BytesTree),
 ) -> Result(Response(BitArray), Error) {
-  use response <- result.then(
+  use response <- result.try(
     request
     |> request.to_uri
     |> uri.to_string
@@ -38,7 +38,7 @@ pub fn send_bits(
 }
 
 pub fn send(req: Request(String)) -> Result(Response(String), Error) {
-  use resp <- result.then(
+  use resp <- result.try(
     req
     |> request.map(bytes_tree.from_string)
     |> send_bits,


### PR DESCRIPTION
Got the following deprecation warning when building gleam_hackney:

  Compiling gleam_hackney
warning: Deprecated value used
   ┌─ .../build/packages/gleam_hackney/src/gleam/hackney.gleam:30:26
   │
30 │   use response <- result.then(
   │                          ^^^^ This value has been deprecated

It was deprecated with this message: This function is an alias of result.try, use that instead