### PR TITLE
fix the example code in the README.md. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,13 @@ choice as it uses the built-in Erlang HTTP client, but this package may be
 useful in some specific situations.
 
 ```shell
-gleam add gleam_hackney@1
+gleam add gleam_hackney@1 gleam_http
 ```
 ```gleam
 import gleam/result
 import gleam/hackney
 import gleam/http/request
 import gleam/http/response
-import gleeunit/should
 
 pub fn main() {
   // Prepare a HTTP request record
@@ -38,6 +37,8 @@ pub fn main() {
     == Ok("application/json")
 
   assert response.body
-    == "{\"message\":\"Hello World\"}")
+    == "{\"message\":\"Hello World\"}"
+
+  Ok(response)
 }
 ```


### PR DESCRIPTION
 the example code does not work. it seems to have accumulated some errors and warnings over time.

1. a minor warning about a Transitive dependency on gleam_http - fixed by explicitly adding gleam_http
2. an unused import of gleeunit/should
3. a stray closing-paren after the final assert
4. a missing last line to set the return type, which after some archeology into the file history, should be "Ok(response)"