### PR TITLE
Configure, receive_timeout, receive_forever, dispatch and dispatch_bits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v1.5.0 - 2026-08-11
 
-- Add configure, receive_timeout_ms, dispatch, and dispatch_bits.
+- Add configure, receive_timeout_ms, receive_forever, dispatch, and dispatch_bits.
 
 ## v1.4.0 - 2026-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.5.0 - 2026-08-11
+
+- Add configure, receive_timeout_ms, dispatch, and dispatch_bits.
+
 ## v1.4.0 - 2026-05-26
 
 - Updated to use hackney 4.x

--- a/README.md
+++ b/README.md
@@ -42,3 +42,12 @@ pub fn main() {
   Ok(response)
 }
 ```
+
+Requests can also be configured before they are sent.
+
+```gleam
+request
+|> hackney.configure
+|> hackney.receive_timeout_ms(5000)
+|> hackney.dispatch
+```

--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ pub fn main() {
 Requests can also be configured before they are sent.
 
 ```gleam
-request
-|> hackney.configure
-|> hackney.receive_timeout_ms(5000)
-|> hackney.dispatch
+hackney.configure()
+|> hackney.receive_timeout(5000)
+|> hackney.dispatch(request)
 ```

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,17 +7,18 @@
 # You should check this file into your source control repository.
 
 packages = [
-  { name = "certifi", version = "2.16.0", build_tools = ["rebar3"], requirements = [], otp_app = "certifi", source = "hex", outer_checksum = "8A64F6669D85E9CC0E5086FCF29A5B13DE57A13EFA23D3582874B9A19303F184" },
+  { name = "certifi", version = "2.17.0", build_tools = ["rebar3"], requirements = [], otp_app = "certifi", source = "hex", outer_checksum = "8122798A17F0293C80DAADA25D0F81C7F4D708C73FEF782C7C9B1950E26E4D21" },
   { name = "gleam_http", version = "4.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "82EA6A717C842456188C190AFB372665EA56CE13D8559BF3B1DD9E40F619EE0C" },
-  { name = "gleam_stdlib", version = "1.0.2", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "0C5506589DF4C63DF5D6FFBB834562D6865C6C2AEE0019D7B37886BD6D128141" },
-  { name = "gleeunit", version = "1.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "254B697FE72EEAD7BF82E941723918E421317813AC49923EE76A18C788C61E72" },
-  { name = "h2", version = "0.6.0", build_tools = ["rebar3"], requirements = [], otp_app = "h2", source = "hex", outer_checksum = "5AC1C05675EFECACBB8014D3923B3A19B1F6C4672F2C103AC24D563169338888" },
-  { name = "hackney", version = "4.0.2", build_tools = ["rebar3"], requirements = ["certifi", "h2", "idna", "mimerl", "parse_trans", "quic", "ssl_verify_fun"], otp_app = "hackney", source = "hex", outer_checksum = "83774852EB40F70023FE88B625907148E8D37313C55512F5AB400513FDE81D4D" },
+  { name = "gleam_stdlib", version = "1.0.5", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "CEE5B6C076A85B45F60C585F4316C63EC8B7127C119D5738C3958A9C4D50404E" },
+  { name = "gleeunit", version = "1.11.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "EC31ABA74256AEA531EDF8169931D775BBB384FED0A8A1BDC4DD9354E3E21826" },
+  { name = "h2", version = "0.11.0", build_tools = ["rebar3"], requirements = [], otp_app = "h2", source = "hex", outer_checksum = "C61F24361D0DC76375EAF35C2BF0E01235D81B7685538DF571DB036467FAC358" },
+  { name = "hackney", version = "4.7.3", build_tools = ["rebar3"], requirements = ["certifi", "h2", "idna", "mimerl", "parse_trans", "ssl_verify_fun", "webtransport"], otp_app = "hackney", source = "hex", outer_checksum = "3F460E01D5A1ABBA39C32D06E9A733BB76E35D1AB87A83868B6BB29D646FE25F" },
   { name = "idna", version = "7.1.0", build_tools = ["rebar3"], requirements = [], otp_app = "idna", source = "hex", outer_checksum = "6AE959A025BF36DF61A8CAB8508D9654891B5426A84C44D82DEAFFD6DDF8C71F" },
   { name = "mimerl", version = "1.5.0", build_tools = ["rebar3"], requirements = [], otp_app = "mimerl", source = "hex", outer_checksum = "DB648CE065BAE14EA84CA8B5DD123F42F49417CEF693541110BF6F9E9BE9ECC4" },
-  { name = "parse_trans", version = "3.4.1", build_tools = ["rebar3"], requirements = [], otp_app = "parse_trans", source = "hex", outer_checksum = "620A406CE75DADA827B82E453C19CF06776BE266F5A67CFF34E1EF2CBB60E49A" },
-  { name = "quic", version = "1.4.3", build_tools = ["rebar3"], requirements = [], otp_app = "quic", source = "hex", outer_checksum = "A12FFEDC8AD8A41D303083C306DEA76141FAB3A54DF8DC0C5E5691FA40E8E619" },
+  { name = "parse_trans", version = "3.4.2", build_tools = ["rebar3"], requirements = [], otp_app = "parse_trans", source = "hex", outer_checksum = "4C25347DE3B7C35732D32E69AB43D1CEEE0BEAE3F3B3ADE1B59CBD3DD224D9CA" },
+  { name = "quic", version = "1.8.0", build_tools = ["rebar3"], requirements = [], otp_app = "quic", source = "hex", outer_checksum = "6B1F8F08A45412AC503BC6771EFB8EDC696BB14079BC48D2CA960B92933DA8A4" },
   { name = "ssl_verify_fun", version = "1.1.7", build_tools = ["mix", "rebar3", "make"], requirements = [], otp_app = "ssl_verify_fun", source = "hex", outer_checksum = "FE4C190E8F37401D30167C8C405EDA19469F34577987C76DDE613E838BBC67F8" },
+  { name = "webtransport", version = "0.4.4", build_tools = ["rebar3"], requirements = ["h2", "quic"], otp_app = "webtransport", source = "hex", outer_checksum = "80A6641E0F6628938CEEE4C9D7A4F6D48A6089890DA1AE3288CA8DAB13A6005E" },
 ]
 
 [requirements]

--- a/src/gleam/hackney.gleam
+++ b/src/gleam/hackney.gleam
@@ -15,34 +15,13 @@ pub type Error {
   Other(Dynamic)
 }
 
-pub opaque type ConfiguredRequest(body) {
-  ConfiguredRequest(request: Request(body), options: SendOptions)
-}
-
-pub opaque type SendOptions {
-  SendOptions(receive_timeout: ReceiveTimeout)
-}
-
-type ReceiveTimeout {
-  DefaultReceiveTimeout
-  ReceiveTimeoutMs(Int)
-}
-
 @external(erlang, "gleam_hackney_ffi", "send")
 fn ffi_send(
   method: String,
   b: String,
   c: List(http.Header),
   d: BytesTree,
-) -> Result(Response(BitArray), Error)
-
-@external(erlang, "gleam_hackney_ffi", "send_with_options")
-fn ffi_send_with_options(
-  method: String,
-  b: String,
-  c: List(http.Header),
-  d: BytesTree,
-  options: SendOptions,
+  options: List(ErlHttpOption),
 ) -> Result(Response(BitArray), Error)
 
 // TODO: test
@@ -54,66 +33,10 @@ pub fn send_bits(
     request
     |> request.to_uri
     |> uri.to_string
-    |> ffi_send(method, _, request.headers, request.body),
+    |> ffi_send(method, _, request.headers, request.body, []),
   )
   let headers = list.map(response.headers, normalise_header)
   Ok(Response(..response, headers: headers))
-}
-
-pub fn configure(request: Request(body)) -> ConfiguredRequest(body) {
-  ConfiguredRequest(
-    request:,
-    options: SendOptions(receive_timeout: DefaultReceiveTimeout),
-  )
-}
-
-pub fn receive_timeout_ms(
-  configured_request: ConfiguredRequest(body),
-  timeout: Int,
-) -> ConfiguredRequest(body) {
-  ConfiguredRequest(
-    ..configured_request,
-    options: SendOptions(receive_timeout: ReceiveTimeoutMs(timeout)),
-  )
-}
-
-pub fn dispatch_bits(
-  configured_request: ConfiguredRequest(BytesTree),
-) -> Result(Response(BitArray), Error) {
-  let ConfiguredRequest(request: http_request, options:) = configured_request
-  let method = http.method_to_string(http_request.method)
-  use response <- result.try(
-    http_request
-    |> request.to_uri
-    |> uri.to_string
-    |> ffi_send_with_options(
-      method,
-      _,
-      http_request.headers,
-      http_request.body,
-      options,
-    ),
-  )
-  let headers = list.map(response.headers, normalise_header)
-  Ok(Response(..response, headers: headers))
-}
-
-pub fn dispatch(
-  configured_request: ConfiguredRequest(String),
-) -> Result(Response(String), Error) {
-  let ConfiguredRequest(request: http_request, options:) = configured_request
-  use received_response <- result.try(
-    ConfiguredRequest(
-      request: request.map(http_request, bytes_tree.from_string),
-      options:,
-    )
-    |> dispatch_bits,
-  )
-
-  case bit_array.to_string(received_response.body) {
-    Ok(body) -> Ok(response.set_body(received_response, body))
-    Error(_) -> Error(InvalidUtf8Response)
-  }
 }
 
 pub fn send(req: Request(String)) -> Result(Response(String), Error) {
@@ -131,4 +54,70 @@ pub fn send(req: Request(String)) -> Result(Response(String), Error) {
 
 fn normalise_header(header: http.Header) -> http.Header {
   #(string.lowercase(header.0), header.1)
+}
+
+pub opaque type Configuration {
+  Builder(receive_timeout: ReceiveTimeout)
+}
+
+type ReceiveTimeout {
+  Infinity
+  ReceiveTimeout(Int)
+}
+
+type ErlHttpOption {
+  RecvTimeout(ReceiveTimeout)
+}
+
+pub fn configure() -> Configuration {
+  Builder(receive_timeout: ReceiveTimeout(5000))
+}
+
+pub fn receive_timeout(
+  _builder: Configuration,
+  milliseconds: Int,
+) -> Configuration {
+  Builder(receive_timeout: ReceiveTimeout(milliseconds))
+}
+
+pub fn receive_forever(_builder: Configuration) -> Configuration {
+  Builder(receive_timeout: Infinity)
+}
+
+pub fn dispatch_bits(
+  config: Configuration,
+  request: Request(BytesTree),
+) -> Result(Response(BitArray), Error) {
+  let method = http.method_to_string(request.method)
+  let erl_http_options = configuration_to_erl_options(config)
+  use response <- result.try(
+    request
+    |> request.to_uri
+    |> uri.to_string
+    |> ffi_send(method, _, request.headers, request.body, erl_http_options),
+  )
+  let headers = list.map(response.headers, normalise_header)
+  Ok(Response(..response, headers: headers))
+}
+
+pub fn dispatch(
+  config: Configuration,
+  request: Request(String),
+) -> Result(Response(String), Error) {
+  let request = request.map(request, bytes_tree.from_string)
+
+  use received_response <- result.try(dispatch_bits(config, request))
+
+  case bit_array.to_string(received_response.body) {
+    Ok(body) -> Ok(response.set_body(received_response, body))
+    Error(_) -> Error(InvalidUtf8Response)
+  }
+}
+
+fn configuration_to_erl_options(config: Configuration) -> List(ErlHttpOption) {
+  let Builder(receive_timeout:) = config
+
+  [
+    RecvTimeout(receive_timeout),
+  ]
 }

--- a/src/gleam/hackney.gleam
+++ b/src/gleam/hackney.gleam
@@ -15,12 +15,34 @@ pub type Error {
   Other(Dynamic)
 }
 
+pub opaque type ConfiguredRequest(body) {
+  ConfiguredRequest(request: Request(body), options: SendOptions)
+}
+
+pub opaque type SendOptions {
+  SendOptions(receive_timeout: ReceiveTimeout)
+}
+
+type ReceiveTimeout {
+  DefaultReceiveTimeout
+  ReceiveTimeoutMs(Int)
+}
+
 @external(erlang, "gleam_hackney_ffi", "send")
 fn ffi_send(
   method: String,
   b: String,
   c: List(http.Header),
   d: BytesTree,
+) -> Result(Response(BitArray), Error)
+
+@external(erlang, "gleam_hackney_ffi", "send_with_options")
+fn ffi_send_with_options(
+  method: String,
+  b: String,
+  c: List(http.Header),
+  d: BytesTree,
+  options: SendOptions,
 ) -> Result(Response(BitArray), Error)
 
 // TODO: test
@@ -36,6 +58,62 @@ pub fn send_bits(
   )
   let headers = list.map(response.headers, normalise_header)
   Ok(Response(..response, headers: headers))
+}
+
+pub fn configure(request: Request(body)) -> ConfiguredRequest(body) {
+  ConfiguredRequest(
+    request:,
+    options: SendOptions(receive_timeout: DefaultReceiveTimeout),
+  )
+}
+
+pub fn receive_timeout_ms(
+  configured_request: ConfiguredRequest(body),
+  timeout: Int,
+) -> ConfiguredRequest(body) {
+  ConfiguredRequest(
+    ..configured_request,
+    options: SendOptions(receive_timeout: ReceiveTimeoutMs(timeout)),
+  )
+}
+
+pub fn dispatch_bits(
+  configured_request: ConfiguredRequest(BytesTree),
+) -> Result(Response(BitArray), Error) {
+  let ConfiguredRequest(request: http_request, options:) = configured_request
+  let method = http.method_to_string(http_request.method)
+  use response <- result.try(
+    http_request
+    |> request.to_uri
+    |> uri.to_string
+    |> ffi_send_with_options(
+      method,
+      _,
+      http_request.headers,
+      http_request.body,
+      options,
+    ),
+  )
+  let headers = list.map(response.headers, normalise_header)
+  Ok(Response(..response, headers: headers))
+}
+
+pub fn dispatch(
+  configured_request: ConfiguredRequest(String),
+) -> Result(Response(String), Error) {
+  let ConfiguredRequest(request: http_request, options:) = configured_request
+  use received_response <- result.try(
+    ConfiguredRequest(
+      request: request.map(http_request, bytes_tree.from_string),
+      options:,
+    )
+    |> dispatch_bits,
+  )
+
+  case bit_array.to_string(received_response.body) {
+    Ok(body) -> Ok(response.set_body(received_response, body))
+    Error(_) -> Error(InvalidUtf8Response)
+  }
 }
 
 pub fn send(req: Request(String)) -> Result(Response(String), Error) {

--- a/src/gleam_hackney_ffi.erl
+++ b/src/gleam_hackney_ffi.erl
@@ -1,9 +1,16 @@
 -module(gleam_hackney_ffi).
 
--export([send/4]).
+-export([send/4, send_with_options/5]).
 
 send(Method, Url, Headers, Body) ->
     Options = [{with_body, true}],
+    send(Method, Url, Headers, Body, Options).
+
+send_with_options(Method, Url, Headers, Body, SendOptions) ->
+    Options = [{with_body, true} | send_options(SendOptions)],
+    send(Method, Url, Headers, Body, Options).
+
+send(Method, Url, Headers, Body, Options) ->
     case hackney:request(Method, Url, Headers, Body, Options) of
         {ok, Status, ResponseHeaders, ResponseBody} -> 
             {ok, {response, Status, ResponseHeaders, ResponseBody}};
@@ -14,3 +21,8 @@ send(Method, Url, Headers, Body) ->
         {error, Error} -> 
             {error, {other, Error}}
     end.
+
+send_options({send_options, default_receive_timeout}) ->
+    [];
+send_options({send_options, {receive_timeout_ms, Timeout}}) ->
+    [{recv_timeout, Timeout}].

--- a/src/gleam_hackney_ffi.erl
+++ b/src/gleam_hackney_ffi.erl
@@ -1,17 +1,11 @@
 -module(gleam_hackney_ffi).
 
--export([send/4, send_with_options/5]).
+-export([send/5]).
 
-send(Method, Url, Headers, Body) ->
-    Options = [{with_body, true}],
-    send(Method, Url, Headers, Body, Options).
-
-send_with_options(Method, Url, Headers, Body, SendOptions) ->
-    Options = [{with_body, true} | send_options(SendOptions)],
-    send(Method, Url, Headers, Body, Options).
 
 send(Method, Url, Headers, Body, Options) ->
-    case hackney:request(Method, Url, Headers, Body, Options) of
+    NormalizedOptions = normalize_options(Options),
+    case hackney:request(Method, Url, Headers, Body, NormalizedOptions) of
         {ok, Status, ResponseHeaders, ResponseBody} -> 
             {ok, {response, Status, ResponseHeaders, ResponseBody}};
 
@@ -22,7 +16,10 @@ send(Method, Url, Headers, Body, Options) ->
             {error, {other, Error}}
     end.
 
-send_options({send_options, default_receive_timeout}) ->
-    [];
-send_options({send_options, {receive_timeout_ms, Timeout}}) ->
-    [{recv_timeout, Timeout}].
+normalize_options(Options) ->
+    [normalize_option(Elem) || Elem <:- Options].
+
+normalize_option({recv_timeout, {receive_timeout, Timeout}}) ->
+    {recv_timeout, Timeout};
+normalize_option(Option) ->
+    Option.

--- a/test/gleam_hackney_test.gleam
+++ b/test/gleam_hackney_test.gleam
@@ -37,6 +37,25 @@ pub fn other_method_request_test() {
   let assert "{\"message\":\"Hello World\"}" = resp.body
 }
 
+pub fn configured_request_test() {
+  let req =
+    request.new()
+    |> request.set_method(Get)
+    |> request.set_host("test-api.service.hmrc.gov.uk")
+    |> request.set_path("/hello/world")
+    |> request.prepend_header("accept", "application/vnd.hmrc.1.0+json")
+
+  let assert Ok(resp) =
+    req
+    |> hackney.configure
+    |> hackney.receive_timeout_ms(5000)
+    |> hackney.dispatch
+
+  let assert 200 = resp.status
+  let assert Ok("application/json") = response.get_header(resp, "content-type")
+  let assert "{\"message\":\"Hello World\"}" = resp.body
+}
+
 pub fn get_request_discards_body_test() {
   let req =
     request.new()

--- a/test/gleam_hackney_test.gleam
+++ b/test/gleam_hackney_test.gleam
@@ -37,7 +37,7 @@ pub fn other_method_request_test() {
   let assert "{\"message\":\"Hello World\"}" = resp.body
 }
 
-pub fn configured_request_test() {
+pub fn configured_timeout_request_test() {
   let req =
     request.new()
     |> request.set_method(Get)
@@ -46,10 +46,27 @@ pub fn configured_request_test() {
     |> request.prepend_header("accept", "application/vnd.hmrc.1.0+json")
 
   let assert Ok(resp) =
-    req
-    |> hackney.configure
-    |> hackney.receive_timeout_ms(5000)
-    |> hackney.dispatch
+    hackney.configure()
+    |> hackney.receive_timeout(5000)
+    |> hackney.dispatch(req)
+
+  let assert 200 = resp.status
+  let assert Ok("application/json") = response.get_header(resp, "content-type")
+  let assert "{\"message\":\"Hello World\"}" = resp.body
+}
+
+pub fn configured_receive_forever_request_test() {
+  let req =
+    request.new()
+    |> request.set_method(Get)
+    |> request.set_host("test-api.service.hmrc.gov.uk")
+    |> request.set_path("/hello/world")
+    |> request.prepend_header("accept", "application/vnd.hmrc.1.0+json")
+
+  let assert Ok(resp) =
+    hackney.configure()
+    |> hackney.receive_forever
+    |> hackney.dispatch(req)
 
   let assert 200 = resp.status
   let assert Ok("application/json") = response.get_header(resp, "content-type")


### PR DESCRIPTION
This PR solves https://github.com/gleam-lang/hackney/issues/15 first actionable point of making requests configurable. Later PR would add the HTTP2.0 configuration